### PR TITLE
Implement spinning wheel game logic

### DIFF
--- a/picker-wheel/src/components/WinnerAnnouncement.tsx
+++ b/picker-wheel/src/components/WinnerAnnouncement.tsx
@@ -1,14 +1,34 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
 type Props = { winner: string }
 
 export function WinnerAnnouncement({ winner }: Props) {
+  const [showAnimation, setShowAnimation] = useState(false)
+
+  useEffect(() => {
+    if (winner) {
+      setShowAnimation(true)
+      const timer = setTimeout(() => setShowAnimation(false), 2000)
+      return () => clearTimeout(timer)
+    }
+  }, [winner])
+
   return (
-    <div className="mt-6" aria-live="polite" aria-atomic="true" role="status">
+    <div className="mt-8" aria-live="polite" aria-atomic="true" role="status">
       {winner ? (
-        <div className="rounded-md border border-green-200 bg-green-50 px-4 py-3 text-green-800">
-          Winner: <strong>{winner}</strong>
+        <div className={`rounded-xl border-2 border-yellow-400 bg-gradient-to-r from-yellow-50 to-orange-50 px-6 py-4 text-center shadow-lg transition-all duration-500 ${showAnimation ? 'scale-105 shadow-xl' : 'scale-100'}`}>
+          <div className="text-2xl mb-2">🎉</div>
+          <div className="text-lg font-bold text-gray-800 mb-1">🏆 Winner! 🏆</div>
+          <div className="text-xl font-extrabold text-orange-600">{winner}</div>
+          <div className="text-sm text-gray-600 mt-2">Congratulations!</div>
         </div>
       ) : (
-        <p className="text-sm text-gray-500">Spin the wheel to pick a winner.</p>
+        <div className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-center text-gray-600">
+          <div className="text-lg mb-1">🎲</div>
+          <p className="text-sm">Spin the wheel to pick a winner!</p>
+        </div>
       )}
     </div>
   )

--- a/picker-wheel/src/lib/__tests__/wheel.test.ts
+++ b/picker-wheel/src/lib/__tests__/wheel.test.ts
@@ -8,11 +8,29 @@ describe('wheel math', () => {
     expect(slices[0].path).toContain('A 100 100') // arc command exists
   })
 
-  test('angleToIndex maps angles to indices', () => {
-    expect(angleToIndex(0, 4)).toBe(0)
-    expect(angleToIndex(89.9, 4)).toBe(0)
-    expect(angleToIndex(90, 4)).toBe(1)
-    expect(angleToIndex(359, 4)).toBe(3)
+  test('angleToIndex maps angles to indices correctly', () => {
+    // Test with 4 slices (90 degrees each)
+    expect(angleToIndex(0, 4)).toBe(0)    // First slice
+    expect(angleToIndex(45, 4)).toBe(0)   // Still first slice
+    expect(angleToIndex(89.9, 4)).toBe(0) // Still first slice
+    expect(angleToIndex(90, 4)).toBe(1)   // Second slice
+    expect(angleToIndex(180, 4)).toBe(2)  // Third slice
+    expect(angleToIndex(270, 4)).toBe(3)  // Fourth slice
+    expect(angleToIndex(359, 4)).toBe(3)  // Still fourth slice
+    expect(angleToIndex(360, 4)).toBe(0)  // Back to first slice
+  })
+
+  test('angleToIndex works with different slice counts', () => {
+    // Test with 3 slices (120 degrees each)
+    expect(angleToIndex(0, 3)).toBe(0)
+    expect(angleToIndex(60, 3)).toBe(0)
+    expect(angleToIndex(120, 3)).toBe(1)
+    expect(angleToIndex(240, 3)).toBe(2)
+    
+    // Test with 6 slices (60 degrees each)
+    expect(angleToIndex(30, 6)).toBe(0)
+    expect(angleToIndex(60, 6)).toBe(1)
+    expect(angleToIndex(120, 6)).toBe(2)
   })
 
   test('shuffleArray produces permutation', () => {

--- a/picker-wheel/src/lib/wheel.ts
+++ b/picker-wheel/src/lib/wheel.ts
@@ -10,6 +10,7 @@ export type Slice = {
 }
 
 // Create pie slice paths for n options, centered at 0,0 radius 100
+// Slices start at the top (12 o'clock) and go clockwise
 export function computeSlices(labels: string[], colors?: string[]): Slice[] {
   const n = Math.max(1, labels.length)
   const anglePer = 360 / n
@@ -18,8 +19,9 @@ export function computeSlices(labels: string[], colors?: string[]): Slice[] {
   const toRad = (deg: number) => (deg * Math.PI) / 180
 
   return labels.map((label, i) => {
-    const startAngle = i * anglePer
-    const endAngle = (i + 1) * anglePer
+    // Start at -90 degrees to position first slice at top (12 o'clock)
+    const startAngle = i * anglePer - 90
+    const endAngle = (i + 1) * anglePer - 90
 
     const largeArc = endAngle - startAngle > 180 ? 1 : 0
 


### PR DESCRIPTION
Implement random starting position, improve pointer visibility, and fix winner calculation for the spinning wheel.

The previous wheel logic had issues with random starting positions, a small pointer, and an incorrect winner calculation due to slices starting at the 3 o'clock position. This PR re-orients the slices to start at the 12 o'clock position, updates the calculation, and enhances the UI for a better user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-b08658da-07ce-4760-93a7-e71a4e3af4da">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b08658da-07ce-4760-93a7-e71a4e3af4da">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

